### PR TITLE
[MAINTENENCE] Remove logo of UHH and Fachbibliotheken

### DIFF
--- a/Resources/Private/Partials/DigitalisateHeader.html
+++ b/Resources/Private/Partials/DigitalisateHeader.html
@@ -33,13 +33,13 @@
             <a href="http://www.sub.uni-hamburg.de/">
                 <img src="/typo3conf/ext/presentation_package/Resources/Public/Images/logo_subhh_x2.png" alt="Staats- und Universitätsbibliothek Hamburg Carl von Ossietzky">
             </a>
-            <a href="https://www.sub.uni-hamburg.de/bibliotheken/universitaetsbibliothek.html">
+            <!--<a href="https://www.sub.uni-hamburg.de/bibliotheken/universitaetsbibliothek.html">
                 <img src="/typo3conf/ext/presentation_package/Resources/Public/Images/logo_fachbib_x2.png" alt="Bibliothekssystem Universität Hamburg">
             </a>
             <a href="http://www.uni-hamburg.de/">
                 <img class="logo-uhh-max" src="/typo3conf/ext/presentation_package/Resources/Public/Images/logo_uhh_claim_x2.png" alt="Universität Hamburg">
                 <img class="logo-uhh-min" src="/typo3conf/ext/presentation_package/Resources/Public/Images/logo_uhh_x2.png" alt="Universität Hamburg">
-            </a>
+            </a>-->
         </div>
 
         <div class="portal-legal-area">


### PR DESCRIPTION
Hallo Chris,

nur ein kleiner PR...unser Bibliotheksdirektor wies darauf hin, dass die Digitalisate ein originärer Dienst der SUB-HH sind und das die Logos des UHH und der Fachbibliotheken entfernt werden sollen.

Dieser PR entfernt sie also...bitte bei nächster Gelegenheit mal einspielen und ausrollen.

Danke und viele Grüße,
Michael